### PR TITLE
Allow disabling isnan() and isinf()

### DIFF
--- a/include/chaiscript/extras/math.hpp
+++ b/include/chaiscript/extras/math.hpp
@@ -437,19 +437,23 @@ namespace chaiscript {
     	  return m;
       }
 
+      #ifndef CHAISCRIPT_EXTRAS_MATH_DISABLE_ISINF
       template<typename Ret, typename Param>
       ModulePtr isinf(ModulePtr m = std::make_shared<Module>())
       {
     	  m->add(chaiscript::fun(static_cast<Ret (*)(Param)>(&std::isinf)), "isinf");
     	  return m;
       }
+      #endif
 
+      #ifndef CHAISCRIPT_EXTRAS_MATH_DISABLE_ISNAN
       template<typename Ret, typename Param>
       ModulePtr isnan(ModulePtr m = std::make_shared<Module>())
       {
     	  m->add(chaiscript::fun(static_cast<Ret (*)(Param)>(&std::isnan)), "isnan");
     	  return m;
       }
+      #endif
 
       template<typename Ret, typename Param>
       ModulePtr isnormal(ModulePtr m = std::make_shared<Module>())
@@ -761,13 +765,17 @@ namespace chaiscript {
         isfinite<bool, double>(m);
         isfinite<bool, long double>(m);
 
+        #ifndef CHAISCRIPT_EXTRAS_MATH_DISABLE_ISINF
         isinf<bool, float>(m);
         isinf<bool, double>(m);
         isinf<bool, long double>(m);
+        #endif
 
+        #ifndef CHAISCRIPT_EXTRAS_MATH_DISABLE_ISNAN
         isnan<bool, float>(m);
         isnan<bool, double>(m);
         isnan<bool, long double>(m);
+        #endif
 
         isnormal<bool, float>(m);
         isnormal<bool, double>(m);

--- a/tests/math.cpp
+++ b/tests/math.cpp
@@ -90,8 +90,12 @@ TEST_CASE( "Math functions work", "[math]" ) {
   // CLASSIFICATION FUNCTIONS
   CHECK(chai.eval<int>("fpclassify(0.5)") == std::fpclassify(0.5));
   CHECK(chai.eval<bool>("isfinite(0.5)") == std::isfinite(0.5));
+  #ifndef CHAISCRIPT_EXTRAS_MATH_DISABLE_ISINF
   CHECK(chai.eval<bool>("isinf(0.5)") == std::isinf(0.5));
+  #endif
+  #ifndef CHAISCRIPT_EXTRAS_MATH_DISABLE_ISNAN
   CHECK(chai.eval<bool>("isnan(0.5)") == std::isnan(0.5));
+  #endif
   CHECK(chai.eval<bool>("isnormal(0.5)") == std::isnormal(0.5));
   CHECK(chai.eval<bool>("signbit(0.5)") == std::signbit(0.5));
 


### PR DESCRIPTION
`isnan()` and `isinf()` were causing compilation errors on GCC6 and GCC7. Having the ability to flag them out entirely fixed the issue.

Not the best fix, but does address the fix for now. Original report at https://github.com/ChaiScript/ChaiScript_Extras/issues/4 .