### PR TITLE
math: Remove duplicate cos() declaration

### DIFF
--- a/include/chaiscript/extras/math.hpp
+++ b/include/chaiscript/extras/math.hpp
@@ -11,7 +11,6 @@ namespace chaiscript {
       ModulePtr cos(ModulePtr m = std::make_shared<Module>())
       {
         m->add(chaiscript::fun([](Param p){ return std::cos(p); }), "cos");
-        m->add(chaiscript::fun([](Param p){ return std::cos(p); }), "cos");
         return m;
       }
 


### PR DESCRIPTION
Looks like we were registering cos() twice.