### PR TITLE
String Methods: Move declaration of vector of strings

### DIFF
--- a/include/chaiscript/extras/string_methods.hpp
+++ b/include/chaiscript/extras/string_methods.hpp
@@ -21,9 +21,6 @@ namespace chaiscript {
     namespace string_methods {
       ModulePtr bootstrap(ModulePtr m = std::make_shared<Module>())
       {
-        // Add lists of strings.
-        m->add(bootstrap::standard_library::vector_type<std::vector<std::string>>("StringVector"));
-
         // string::replace(std::string search, std::string replace)
         m->add(fun([](const std::string& subject, const std::string& search, const std::string& replace) {
           std::string result(subject);

--- a/include/chaiscript/extras/string_methods.hpp
+++ b/include/chaiscript/extras/string_methods.hpp
@@ -9,6 +9,10 @@
  * string::split(string token)
  * string::toLowerCase()
  * string::toUpperCase()
+ *
+ * To allow selecting indexes from split(), ensure VectorString type is added:
+ *
+ * chai.add(chaiscript::bootstrap::standard_library::vector_type<std::vector<std::string>>("VectorString"));
  */
 #include <algorithm>
 #include <string>

--- a/tests/string_methods.cpp
+++ b/tests/string_methods.cpp
@@ -12,6 +12,7 @@ TEST_CASE( "string_methods functions work", "[string_methods]" ) {
 
   // Add the string_methods module.
   auto stringmethods = chaiscript::extras::string_methods::bootstrap();
+  chai.add(chaiscript::bootstrap::standard_library::vector_type<std::vector<std::string>>("StringVector"));
   chai.add(stringmethods);
 
   // replace(string, string)


### PR DESCRIPTION
This fixes the use of std::vector across different standard library definitions.