### PR TITLE
Fix #26: string_methods.cpp does not support ChaiScript 6+

### DIFF
--- a/cmake/chaiscript.cmake
+++ b/cmake/chaiscript.cmake
@@ -1,4 +1,4 @@
-set(CHAISCRIPT_VERSION 5.8.6)
+set(CHAISCRIPT_VERSION 6.1.0)
 find_package(chaiscript ${CHAISCRIPT_VERSION} QUIET)
 
 if (NOT chaiscript_FOUND)

--- a/include/chaiscript/extras/string_methods.hpp
+++ b/include/chaiscript/extras/string_methods.hpp
@@ -15,7 +15,8 @@
  *
  * To allow selecting indexes from split(), ensure the vector of strings type is added:
  *
- *     chai.add(chaiscript::bootstrap::standard_library::vector_type<std::vector<std::string>>("VectorString"));
+ *     auto m = chaiscript::extras::string_methods::bootstrap();
+ *     chai.add(m);
  */
 
 #ifndef CHAISCRIPT_EXTRAS_STRING_METHODS_HPP_
@@ -176,6 +177,8 @@ namespace chaiscript {
         m->add(fun(includesChar), "includes");
         m->add(fun(trimStart), "trimStart");
         m->add(fun(trimEnd), "trimEnd");
+
+        chaiscript::bootstrap::standard_library::vector_type<std::vector<std::string>>("VectorString", *m);
 
         return m;
       }

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -6462,7 +6462,7 @@ namespace Catch {
         static bool isSet;
         static struct sigaction oldSigActions[];// [sizeof(signalDefs) / sizeof(SignalDefs)];
         static stack_t oldSigStack;
-        static char altStackMem[];
+        static char altStackMem[32768];
 
         static void handleSignal( int sig );
 
@@ -6597,7 +6597,7 @@ namespace Catch {
         isSet = true;
         stack_t sigStack;
         sigStack.ss_sp = altStackMem;
-        sigStack.ss_size = SIGSTKSZ;
+        sigStack.ss_size = sizeof(altStackMem);
         sigStack.ss_flags = 0;
         sigaltstack(&sigStack, &oldSigStack);
         struct sigaction sa = { };
@@ -6628,7 +6628,7 @@ namespace Catch {
     bool FatalConditionHandler::isSet = false;
     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
     stack_t FatalConditionHandler::oldSigStack = {};
-    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+    char FatalConditionHandler::altStackMem[32768] = {};
 
 } // namespace Catch
 

--- a/tests/math.cpp
+++ b/tests/math.cpp
@@ -3,7 +3,6 @@
 #include "catch.hpp"
 
 #include <chaiscript/chaiscript.hpp>
-#include <chaiscript/chaiscript_stdlib.hpp>
 #include "../include/chaiscript/extras/math.hpp"
 
 #include <iostream>
@@ -11,8 +10,7 @@
 TEST_CASE( "Math functions work", "[math]" ) {
   auto mathlib = chaiscript::extras::math::bootstrap();
 
-  auto stdlib = chaiscript::Std_Lib::library();
-  chaiscript::ChaiScript chai(stdlib);
+  chaiscript::ChaiScript chai;
   chai.add(mathlib);
 
   // TRIG FUNCTIONS

--- a/tests/string_methods.cpp
+++ b/tests/string_methods.cpp
@@ -3,17 +3,14 @@
 #include "catch.hpp"
 
 #include <chaiscript/chaiscript.hpp>
-#include <chaiscript/chaiscript_stdlib.hpp>
 #include "../include/chaiscript/extras/string_methods.hpp"
 
 TEST_CASE( "string_methods functions work", "[string_methods]" ) {
   // Create the ChaiScript environment with stdlib available.
-  auto stdlib = chaiscript::Std_Lib::library();
-  chaiscript::ChaiScript chai(stdlib);
+  chaiscript::ChaiScript chai;
 
   // Add the string_methods module.
   auto stringmethods = chaiscript::extras::string_methods::bootstrap();
-  chai.add(chaiscript::bootstrap::standard_library::vector_type<std::vector<std::string>>("StringVector"));
   chai.add(stringmethods);
 
   // replace(string, string)


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #26: Update to ChaiScript 6.1.0 and fix vector_type API
> ChaiScript 6+ changed the vector_type signature from returning a ModulePtr
> to taking a Module& parameter and returning void. The ChaiScript constructor
> also no longer accepts a ModulePtr for stdlib. Updated bootstrap() to register
> the vector_type for std::vector<std::string> directly within the module, and
> updated tests to use the new ChaiScript 6+ API. Fixed Catch SIGSTKSZ
> compile error on newer glibc where SIGSTKSZ is no longer a constant expression.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 cmake/chaiscript.cmake                       | 2 +-
 include/chaiscript/extras/string_methods.hpp | 5 ++++-
 tests/catch.hpp                              | 6 +++---
 tests/math.cpp                               | 4 +---
 tests/string_methods.cpp                     | 5 +----
 5 files changed, 10 insertions(+), 12 deletions(-)
```

Closes #26

_Triggered by @lefticus._