### PR TITLE
Fix #3: Add random number generator

### DIFF
--- a/include/chaiscript/extras/random.hpp
+++ b/include/chaiscript/extras/random.hpp
@@ -9,20 +9,20 @@
 namespace chaiscript {
   namespace extras {
     namespace random {
-      class Random_Engine {
+      class MT19937_Engine {
       public:
-        Random_Engine()
+        MT19937_Engine()
           : m_engine(std::random_device{}())
         {
         }
 
-        explicit Random_Engine(unsigned int t_seed)
+        explicit MT19937_Engine(unsigned int t_seed)
           : m_engine(t_seed)
         {
         }
 
-        Random_Engine(const Random_Engine &) = default;
-        Random_Engine &operator=(const Random_Engine &) = default;
+        MT19937_Engine(const MT19937_Engine &) = default;
+        MT19937_Engine &operator=(const MT19937_Engine &) = default;
 
         void seed(unsigned int t_seed) {
           m_engine.seed(t_seed);
@@ -44,16 +44,16 @@ namespace chaiscript {
 
       ModulePtr bootstrap(ModulePtr m = std::make_shared<Module>())
       {
-        m->add(user_type<Random_Engine>(), "Random_Engine");
-        m->add(constructor<Random_Engine ()>(), "Random_Engine");
-        m->add(constructor<Random_Engine (unsigned int)>(), "Random_Engine");
-        m->add(constructor<Random_Engine (const Random_Engine &)>(), "Random_Engine");
+        m->add(user_type<MT19937_Engine>(), "MT19937_Engine");
+        m->add(constructor<MT19937_Engine ()>(), "MT19937_Engine");
+        m->add(constructor<MT19937_Engine (unsigned int)>(), "MT19937_Engine");
+        m->add(constructor<MT19937_Engine (const MT19937_Engine &)>(), "MT19937_Engine");
 
-        m->add(fun(&Random_Engine::seed), "seed");
-        m->add(fun(&Random_Engine::random_int), "random_int");
-        m->add(fun(&Random_Engine::random_float), "random_float");
+        m->add(fun(&MT19937_Engine::seed), "seed");
+        m->add(fun(&MT19937_Engine::random_int), "random_int");
+        m->add(fun(&MT19937_Engine::random_float), "random_float");
 
-        m->add(fun([](Random_Engine &t_lhs, const Random_Engine &t_rhs) -> Random_Engine & {
+        m->add(fun([](MT19937_Engine &t_lhs, const MT19937_Engine &t_rhs) -> MT19937_Engine & {
           t_lhs = t_rhs;
           return t_lhs;
         }), "=");

--- a/include/chaiscript/extras/random.hpp
+++ b/include/chaiscript/extras/random.hpp
@@ -1,0 +1,41 @@
+#ifndef CHAISCRIPT_EXTRAS_RANDOM_HPP_
+#define CHAISCRIPT_EXTRAS_RANDOM_HPP_
+
+#include <memory>
+#include <random>
+
+#include <chaiscript/chaiscript.hpp>
+
+namespace chaiscript {
+  namespace extras {
+    namespace random {
+      ModulePtr bootstrap(ModulePtr m = std::make_shared<Module>())
+      {
+        auto engine = std::make_shared<std::mt19937>(std::random_device{}());
+
+        m->add(chaiscript::fun([engine]() -> int {
+          std::uniform_int_distribution<int> dist(0, RAND_MAX);
+          return dist(*engine);
+        }), "rand");
+
+        m->add(chaiscript::fun([engine](int max) -> int {
+          std::uniform_int_distribution<int> dist(0, max);
+          return dist(*engine);
+        }), "rand");
+
+        m->add(chaiscript::fun([engine](int min, int max) -> int {
+          std::uniform_int_distribution<int> dist(min, max);
+          return dist(*engine);
+        }), "rand");
+
+        m->add(chaiscript::fun([engine](unsigned int seed) {
+          engine->seed(seed);
+        }), "srand");
+
+        return m;
+      }
+    }
+  }
+}
+
+#endif /* CHAISCRIPT_EXTRAS_RANDOM_HPP_ */

--- a/include/chaiscript/extras/random.hpp
+++ b/include/chaiscript/extras/random.hpp
@@ -9,28 +9,54 @@
 namespace chaiscript {
   namespace extras {
     namespace random {
+      class Random_Engine {
+      public:
+        Random_Engine()
+          : m_engine(std::random_device{}())
+        {
+        }
+
+        explicit Random_Engine(unsigned int t_seed)
+          : m_engine(t_seed)
+        {
+        }
+
+        Random_Engine(const Random_Engine &) = default;
+        Random_Engine &operator=(const Random_Engine &) = default;
+
+        void seed(unsigned int t_seed) {
+          m_engine.seed(t_seed);
+        }
+
+        int random_int(int t_min, int t_max) {
+          std::uniform_int_distribution<int> dist(t_min, t_max);
+          return dist(m_engine);
+        }
+
+        double random_float(double t_min, double t_max) {
+          std::uniform_real_distribution<double> dist(t_min, t_max);
+          return dist(m_engine);
+        }
+
+      private:
+        std::mt19937 m_engine;
+      };
+
       ModulePtr bootstrap(ModulePtr m = std::make_shared<Module>())
       {
-        auto engine = std::make_shared<std::mt19937>(std::random_device{}());
+        m->add(user_type<Random_Engine>(), "Random_Engine");
+        m->add(constructor<Random_Engine ()>(), "Random_Engine");
+        m->add(constructor<Random_Engine (unsigned int)>(), "Random_Engine");
+        m->add(constructor<Random_Engine (const Random_Engine &)>(), "Random_Engine");
 
-        m->add(chaiscript::fun([engine]() -> int {
-          std::uniform_int_distribution<int> dist(0, RAND_MAX);
-          return dist(*engine);
-        }), "rand");
+        m->add(fun(&Random_Engine::seed), "seed");
+        m->add(fun(&Random_Engine::random_int), "random_int");
+        m->add(fun(&Random_Engine::random_float), "random_float");
 
-        m->add(chaiscript::fun([engine](int max) -> int {
-          std::uniform_int_distribution<int> dist(0, max);
-          return dist(*engine);
-        }), "rand");
-
-        m->add(chaiscript::fun([engine](int min, int max) -> int {
-          std::uniform_int_distribution<int> dist(min, max);
-          return dist(*engine);
-        }), "rand");
-
-        m->add(chaiscript::fun([engine](unsigned int seed) {
-          engine->seed(seed);
-        }), "srand");
+        m->add(fun([](Random_Engine &t_lhs, const Random_Engine &t_rhs) -> Random_Engine & {
+          t_lhs = t_rhs;
+          return t_lhs;
+        }), "=");
 
         return m;
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,3 +50,9 @@ add_executable(string_methods_test string_methods.cpp)
 target_link_libraries(string_methods_test ${LIBS})
 target_include_directories(string_methods_test PUBLIC "${chaiscript_SOURCE_DIR}/include")
 ADD_CATCH_TESTS(string_methods_test)
+
+# Random
+add_executable(random_test random.cpp)
+target_link_libraries(random_test ${LIBS})
+target_include_directories(random_test PUBLIC "${chaiscript_SOURCE_DIR}/include")
+ADD_CATCH_TESTS(random_test)

--- a/tests/math.cpp
+++ b/tests/math.cpp
@@ -1,4 +1,5 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 //#include <sstream>
 #include "catch.hpp"
 

--- a/tests/random.cpp
+++ b/tests/random.cpp
@@ -6,43 +6,70 @@
 #include <chaiscript/chaiscript_stdlib.hpp>
 #include "../include/chaiscript/extras/random.hpp"
 
-TEST_CASE( "Random functions work", "[random]" ) {
+TEST_CASE( "Random_Engine type is usable in ChaiScript", "[random]" ) {
   auto randomlib = chaiscript::extras::random::bootstrap();
 
   auto stdlib = chaiscript::Std_Lib::library();
   chaiscript::ChaiScript chai(stdlib);
   chai.add(randomlib);
 
-  SECTION("rand() returns a non-negative integer") {
-    const auto result = chai.eval<int>("rand()");
+  SECTION("default constructor creates a valid engine") {
+    const auto result = chai.eval<int>("var rng = Random_Engine(); rng.random_int(0, 100)");
     CHECK(result >= 0);
+    CHECK(result <= 100);
   }
 
-  SECTION("rand(max) returns a value in [0, max]") {
-    const auto result = chai.eval<int>("rand(10)");
+  SECTION("seeded constructor creates a valid engine") {
+    const auto result = chai.eval<int>("var rng = Random_Engine(42u); rng.random_int(0, 100)");
     CHECK(result >= 0);
-    CHECK(result <= 10);
+    CHECK(result <= 100);
   }
 
-  SECTION("rand(min, max) returns a value in [min, max]") {
-    const auto result = chai.eval<int>("rand(5, 10)");
+  SECTION("seed produces deterministic sequences") {
+    chai.eval("var rng = Random_Engine()");
+    chai.eval("rng.seed(42u)");
+    const auto first = chai.eval<int>("rng.random_int(0, 1000)");
+    chai.eval("rng.seed(42u)");
+    const auto second = chai.eval<int>("rng.random_int(0, 1000)");
+    CHECK(first == second);
+  }
+
+  SECTION("copy constructor copies engine state") {
+    chai.eval("var rng = Random_Engine(99u)");
+    chai.eval("var rng2 = Random_Engine(rng)");
+    const auto a = chai.eval<int>("rng.random_int(0, 1000)");
+    const auto b = chai.eval<int>("rng2.random_int(0, 1000)");
+    CHECK(a == b);
+  }
+
+  SECTION("assignment copies engine state") {
+    chai.eval("var rng = Random_Engine(77u)");
+    chai.eval("var rng2 = Random_Engine()");
+    chai.eval("rng2 = rng");
+    const auto a = chai.eval<int>("rng.random_int(0, 1000)");
+    const auto b = chai.eval<int>("rng2.random_int(0, 1000)");
+    CHECK(a == b);
+  }
+
+  SECTION("random_int returns values in range") {
+    chai.eval("var rng = Random_Engine(42u)");
+    const auto result = chai.eval<int>("rng.random_int(5, 10)");
     CHECK(result >= 5);
     CHECK(result <= 10);
   }
 
-  SECTION("srand(seed) produces deterministic results") {
-    chai.eval("srand(42)");
-    const auto first = chai.eval<int>("rand(0, 1000)");
-    chai.eval("srand(42)");
-    const auto second = chai.eval<int>("rand(0, 1000)");
-    CHECK(first == second);
+  SECTION("random_float returns values in range") {
+    chai.eval("var rng = Random_Engine(42u)");
+    const auto result = chai.eval<double>("rng.random_float(0.0, 1.0)");
+    CHECK(result >= 0.0);
+    CHECK(result < 1.0);
   }
 
-  SECTION("rand() with same seed is deterministic") {
-    chai.eval("srand(123)");
-    const auto a = chai.eval<int>("rand()");
-    chai.eval("srand(123)");
-    const auto b = chai.eval<int>("rand()");
-    CHECK(a == b);
+  SECTION("different seeds produce different sequences") {
+    chai.eval("var rng1 = Random_Engine(1u)");
+    chai.eval("var rng2 = Random_Engine(2u)");
+    const auto a = chai.eval<int>("rng1.random_int(0, 1000000)");
+    const auto b = chai.eval<int>("rng2.random_int(0, 1000000)");
+    CHECK(a != b);
   }
 }

--- a/tests/random.cpp
+++ b/tests/random.cpp
@@ -1,0 +1,48 @@
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include "catch.hpp"
+
+#include <chaiscript/chaiscript.hpp>
+#include <chaiscript/chaiscript_stdlib.hpp>
+#include "../include/chaiscript/extras/random.hpp"
+
+TEST_CASE( "Random functions work", "[random]" ) {
+  auto randomlib = chaiscript::extras::random::bootstrap();
+
+  auto stdlib = chaiscript::Std_Lib::library();
+  chaiscript::ChaiScript chai(stdlib);
+  chai.add(randomlib);
+
+  SECTION("rand() returns a non-negative integer") {
+    const auto result = chai.eval<int>("rand()");
+    CHECK(result >= 0);
+  }
+
+  SECTION("rand(max) returns a value in [0, max]") {
+    const auto result = chai.eval<int>("rand(10)");
+    CHECK(result >= 0);
+    CHECK(result <= 10);
+  }
+
+  SECTION("rand(min, max) returns a value in [min, max]") {
+    const auto result = chai.eval<int>("rand(5, 10)");
+    CHECK(result >= 5);
+    CHECK(result <= 10);
+  }
+
+  SECTION("srand(seed) produces deterministic results") {
+    chai.eval("srand(42)");
+    const auto first = chai.eval<int>("rand(0, 1000)");
+    chai.eval("srand(42)");
+    const auto second = chai.eval<int>("rand(0, 1000)");
+    CHECK(first == second);
+  }
+
+  SECTION("rand() with same seed is deterministic") {
+    chai.eval("srand(123)");
+    const auto a = chai.eval<int>("rand()");
+    chai.eval("srand(123)");
+    const auto b = chai.eval<int>("rand()");
+    CHECK(a == b);
+  }
+}

--- a/tests/random.cpp
+++ b/tests/random.cpp
@@ -6,7 +6,7 @@
 #include <chaiscript/chaiscript_stdlib.hpp>
 #include "../include/chaiscript/extras/random.hpp"
 
-TEST_CASE( "Random_Engine type is usable in ChaiScript", "[random]" ) {
+TEST_CASE( "MT19937_Engine type is usable in ChaiScript", "[random]" ) {
   auto randomlib = chaiscript::extras::random::bootstrap();
 
   auto stdlib = chaiscript::Std_Lib::library();
@@ -14,19 +14,19 @@ TEST_CASE( "Random_Engine type is usable in ChaiScript", "[random]" ) {
   chai.add(randomlib);
 
   SECTION("default constructor creates a valid engine") {
-    const auto result = chai.eval<int>("var rng = Random_Engine(); rng.random_int(0, 100)");
+    const auto result = chai.eval<int>("var rng = MT19937_Engine(); rng.random_int(0, 100)");
     CHECK(result >= 0);
     CHECK(result <= 100);
   }
 
   SECTION("seeded constructor creates a valid engine") {
-    const auto result = chai.eval<int>("var rng = Random_Engine(42u); rng.random_int(0, 100)");
+    const auto result = chai.eval<int>("var rng = MT19937_Engine(42u); rng.random_int(0, 100)");
     CHECK(result >= 0);
     CHECK(result <= 100);
   }
 
   SECTION("seed produces deterministic sequences") {
-    chai.eval("var rng = Random_Engine()");
+    chai.eval("var rng = MT19937_Engine()");
     chai.eval("rng.seed(42u)");
     const auto first = chai.eval<int>("rng.random_int(0, 1000)");
     chai.eval("rng.seed(42u)");
@@ -35,16 +35,16 @@ TEST_CASE( "Random_Engine type is usable in ChaiScript", "[random]" ) {
   }
 
   SECTION("copy constructor copies engine state") {
-    chai.eval("var rng = Random_Engine(99u)");
-    chai.eval("var rng2 = Random_Engine(rng)");
+    chai.eval("var rng = MT19937_Engine(99u)");
+    chai.eval("var rng2 = MT19937_Engine(rng)");
     const auto a = chai.eval<int>("rng.random_int(0, 1000)");
     const auto b = chai.eval<int>("rng2.random_int(0, 1000)");
     CHECK(a == b);
   }
 
   SECTION("assignment copies engine state") {
-    chai.eval("var rng = Random_Engine(77u)");
-    chai.eval("var rng2 = Random_Engine()");
+    chai.eval("var rng = MT19937_Engine(77u)");
+    chai.eval("var rng2 = MT19937_Engine()");
     chai.eval("rng2 = rng");
     const auto a = chai.eval<int>("rng.random_int(0, 1000)");
     const auto b = chai.eval<int>("rng2.random_int(0, 1000)");
@@ -52,22 +52,22 @@ TEST_CASE( "Random_Engine type is usable in ChaiScript", "[random]" ) {
   }
 
   SECTION("random_int returns values in range") {
-    chai.eval("var rng = Random_Engine(42u)");
+    chai.eval("var rng = MT19937_Engine(42u)");
     const auto result = chai.eval<int>("rng.random_int(5, 10)");
     CHECK(result >= 5);
     CHECK(result <= 10);
   }
 
   SECTION("random_float returns values in range") {
-    chai.eval("var rng = Random_Engine(42u)");
+    chai.eval("var rng = MT19937_Engine(42u)");
     const auto result = chai.eval<double>("rng.random_float(0.0, 1.0)");
     CHECK(result >= 0.0);
     CHECK(result < 1.0);
   }
 
   SECTION("different seeds produce different sequences") {
-    chai.eval("var rng1 = Random_Engine(1u)");
-    chai.eval("var rng2 = Random_Engine(2u)");
+    chai.eval("var rng1 = MT19937_Engine(1u)");
+    chai.eval("var rng2 = MT19937_Engine(2u)");
     const auto a = chai.eval<int>("rng1.random_int(0, 1000000)");
     const auto b = chai.eval<int>("rng2.random_int(0, 1000000)");
     CHECK(a != b);

--- a/tests/string_methods.cpp
+++ b/tests/string_methods.cpp
@@ -1,4 +1,5 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include <string>
 #include "catch.hpp"
 


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #3: Add random number generator module
> Add chaiscript::extras::random providing rand(), rand(max), rand(min, max),
> and srand(seed) functions using C++11's <random> facilities (std::mt19937
> with std::uniform_int_distribution). The engine state is shared via
> std::shared_ptr so srand() produces deterministic sequences. Also add
> CATCH_CONFIG_NO_POSIX_SIGNALS to test files to fix SIGSTKSZ build errors
> on newer glibc.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 include/chaiscript/extras/random.hpp | 41 ++++++++++++++++++++++++++++++
 tests/CMakeLists.txt                 |  6 +++++
 tests/math.cpp                       |  1 +
 tests/random.cpp                     | 48 ++++++++++++++++++++++++++++++++++++
 tests/string_methods.cpp             |  1 +
 5 files changed, 97 insertions(+)
```

Closes #3

_Triggered by @lefticus._