### PR TITLE
Fix CI build: accommodate CMake 4.x and skip upstream chai REPL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11) # FetchContent requires CMake 3.11
+cmake_minimum_required(VERSION 3.16)
 project(chaiscript_extras)
 
 # MINGW does not yet support C++11's concurrency features

--- a/cmake/chaiscript.cmake
+++ b/cmake/chaiscript.cmake
@@ -4,6 +4,14 @@ find_package(chaiscript ${CHAISCRIPT_VERSION} QUIET)
 if (NOT chaiscript_FOUND)
   include(FetchContent)
 
+  # FetchContent_Populate is deprecated in CMake 3.30+, but it still gives us the
+  # fine-grained control (EXCLUDE_FROM_ALL on add_subdirectory) we need to keep
+  # the upstream `chai` REPL target out of the default build. Opt into the OLD
+  # behaviour explicitly.
+  if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+  endif()
+
   FetchContent_Declare(
     chaiscript
     GIT_REPOSITORY https://github.com/ChaiScript/ChaiScript.git
@@ -12,14 +20,21 @@ if (NOT chaiscript_FOUND)
 
   FetchContent_GetProperties(chaiscript)
   if (NOT chaiscript_POPULATED)
-    set(FETCHCONTENT_QUIET NO)
     FetchContent_Populate(chaiscript)
 
     set(BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
-    set(BUILD_MODULES ON CACHE BOOL "" FORCE)
+    set(BUILD_MODULES OFF CACHE BOOL "" FORCE)
     set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
     set(BUILD_LIBFUZZ_TESTER OFF CACHE BOOL "" FORCE)
 
-    add_subdirectory(${chaiscript_SOURCE_DIR} ${chaiscript_BINARY_DIR})
+    # ChaiScript 6.1.0's root CMakeLists.txt declares
+    # cmake_minimum_required(VERSION 2.8), which CMake 4.x refuses. Force a
+    # floor so the fetched subproject is accepted.
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
+    # EXCLUDE_FROM_ALL keeps ChaiScript's `chai` REPL out of the default build.
+    # We only consume ChaiScript's headers here, and its src/main.cpp in 6.1.0
+    # does not compile on current MSVC (missing <chrono> include).
+    add_subdirectory(${chaiscript_SOURCE_DIR} ${chaiscript_BINARY_DIR} EXCLUDE_FROM_ALL)
   endif()
 endif()


### PR DESCRIPTION
## Summary

Fixes the CI failures from #34 (tracked in #33). The build breakage is rooted in the outdated `CMakeLists.txt` that ships with ChaiScript 6.1.0 and gets pulled in via `FetchContent`.

Two independent CMake issues:

- **macOS Configure error** — runners now ship CMake 4.x, which removes support for `cmake_minimum_required(VERSION < 3.5)`. ChaiScript 6.1.0's root `CMakeLists.txt` still declares `VERSION 2.8` and configure aborts. Fixed by setting `CMAKE_POLICY_VERSION_MINIMUM 3.5` just before `add_subdirectory`, forcing an acceptable floor for the transitive project.

- **Windows MSVC Build error** — ChaiScript 6.1.0's `src/main.cpp` (the `chai` REPL) has a missing `<chrono>` include and fails to compile under current MSVC (`'high_resolution_clock': is not a class or namespace name`). The REPL target is declared unconditionally in the subproject, so `EXCLUDE_FROM_ALL` on `add_subdirectory` keeps it out of the default build. `chaiscript_extras` only consumes ChaiScript's headers, so no functionality is lost.

Drive-by modernization: bump `cmake_minimum_required` to 3.16, explicitly opt into `CMP0169 OLD` so the intentional `FetchContent_Populate` call stays quiet on CMake 3.30+, and drop the now-unused `BUILD_MODULES ON` override (modules aren't needed by the tests, and `EXCLUDE_FROM_ALL` would skip them regardless).

## Out of scope

The Linux ASAN/UBSAN job still fails on `string_methods_test` with a heap-use-after-free originating in `chaiscript::extras::string_methods::split` when accessed via a chained index expression (e.g. `split(",")[1]`). That is a **runtime** bug in the extras+ChaiScript 6.1.0 interaction — not a CMake issue — and should be tracked separately.

## Test plan

- [x] Local clean configure on CMake 3.31 — no errors, deprecation warnings silenced
- [x] `cmake --build` (Debug) — succeeds, `chai` REPL **not** built
- [x] `cmake --build` (Release) — succeeds, `chai` REPL **not** built
- [x] `ctest` (Debug) — both tests pass
- [x] `ctest` (Release) — both tests pass
- [ ] GitHub Actions CI — macOS/Windows/Linux non-sanitizer jobs should go green; Linux sanitizers will still fail on the pre-existing runtime bug noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)